### PR TITLE
１１：データ構造（４）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": ["chmax", "chmin"],
   "files.associations": {
     "iosfwd": "cpp",
-    "vector": "cpp"
+    "vector": "cpp",
+    "iostream": "cpp"
   }
 }

--- a/chapter_11/union_find.cpp
+++ b/chapter_11/union_find.cpp
@@ -1,0 +1,3 @@
+# include <iostream>
+# include <vector>
+using namespace std;

--- a/chapter_11/union_find.cpp
+++ b/chapter_11/union_find.cpp
@@ -1,3 +1,61 @@
 # include <iostream>
 # include <vector>
 using namespace std;
+
+// Union Find
+struct UnionFind {
+  // par:各頂点の親頂点の番号 siz:各頂点が属する根付き木の頂点数
+  vector<int> par, siz;
+
+  // 初期化
+  UnionFind(int n) : par(n, -1), siz(n, 1) {} // parの初期値は-1(親)、sizの初期値は1（一つだから）
+
+  // 根を求める
+  int root(int x) {
+    if (par[x] == -1) return x; // xが根の場合はxを返す
+    return par[x] = root(par[x]);
+  }
+
+  // xとyが同じグループに属するかどうか
+  bool isSame(int x, int y) {
+    return root(x) == root(y);
+  };
+
+  // xを含むグループとyを含むグループとを併合する
+  bool unite(int x, int y) {
+    // x, y をそれぞれ根まで移動する
+    x = root(x); 
+    y = root(y);
+
+    // すでに同じグループの時は何もしない
+    if (x == y) return false;
+
+    // union by size (y側のサイズが小さくなるようにする)
+    if (siz[x] < siz[y]) swap(x, y);
+
+    // yをxの子とする
+    par[y] = x;
+    siz[x] += siz[y];
+    return true;
+  };
+
+  // xを含むグループのサイズ
+  int size(int x) {
+    return siz[root(x)];
+  }
+};
+
+
+int main() {
+  UnionFind uf(7); // {0}, {1}, {2}, {3}, {4}, {5}, {6}
+  
+  uf.unite(1, 2); // {0}, {1, 2}, {3}, {4}, {5}, {6}
+  uf.unite(2, 3); // {0}, {1, 2, 3}, {4}, {5}, {6}
+  uf.unite(5, 6); // {0}, {1, 2, 3}, {4}, {5, 6}
+  cout << uf.isSame(1, 3) << endl; // true
+  cout << uf.isSame(2, 5) << endl; // false
+
+  uf.unite(1, 6); // {0}, {1, 2, 3, 5, 6}, {4}
+  cout << uf.isSame(2, 5) << endl; // false
+}
+


### PR DESCRIPTION
## データ構造（４）
Union Find。
### 概要
Union Find … グループ分けを効率的に管理するデータ構造であり、根つき木の構造を用いている。
以下のクエリを高速に処理することができる。
- issame(x, y)：要素(x, y)が同じグループに属するかどうか
- unite(x, y)：要素xを含むグループと、要素yを含むグループとを併合

どちらのクエリもまず根まで探索する必要があるため、Union Findのクエリ処理においては根を求める処理が中核を担っているといえる。
根つき木の高さをhとすると、最大で計算量が`O(h)`となってしまい、非効率的である。
そのため以下の二点を工夫し改善する。
- union by size（union by rank）
- 経路圧縮

どちらかを実行することで、計算量は`O(logN)`に、両方実行することで`O(1)`まで短縮できる。

### union by size
併合クエリunion(x, y)に関する工夫。
「頂点数の少ない方の根つき木を、頂点数の多い方の根つき木に併合する」という考え方。

### 経路圧縮
根を求める関数root(x, y)に関する工夫。
根に到達するまでの経路中の各頂点に対し、その親を根に張り替える。